### PR TITLE
Nest definition of DecodingError in Base64 enum

### DIFF
--- a/Sources/ExtrasBase64/DecodingError.swift
+++ b/Sources/ExtrasBase64/DecodingError.swift
@@ -1,7 +1,8 @@
-
-public enum DecodingError: Error, Equatable {
-    case invalidLength
-    case invalidCharacter(UInt8)
-    case unexpectedPaddingCharacter
-    case unexpectedEnd
+public extension Base64 {
+    enum DecodingError: Error, Equatable {
+        case invalidLength
+        case invalidCharacter(UInt8)
+        case unexpectedPaddingCharacter
+        case unexpectedEnd
+    }
 }

--- a/Tests/ExtrasBase64Tests/ChromiumTests.swift
+++ b/Tests/ExtrasBase64Tests/ChromiumTests.swift
@@ -82,7 +82,7 @@ class ChromiumTests: XCTestCase {
 
     func testBase64DecodingWithPoop() {
         XCTAssertThrowsError(_ = try Base64.decode(bytes: "💩".utf8)) { error in
-            XCTAssertEqual(error as? DecodingError, .invalidCharacter(240))
+            XCTAssertEqual(error as? Base64.DecodingError, .invalidCharacter(240))
         }
     }
 
@@ -112,7 +112,7 @@ class ChromiumTests: XCTestCase {
 
     func testBase64DecodingWithInvalidLength() {
         XCTAssertThrowsError(_ = try Base64.decode(bytes: "AAAAA".utf8)) { error in
-            XCTAssertEqual(error as? DecodingError, .invalidLength)
+            XCTAssertEqual(error as? Base64.DecodingError, .invalidLength)
         }
     }
 


### PR DESCRIPTION
Fixes #24 