### PR TITLE
Fixed issue where decoding of empty bytes crashed.

### DIFF
--- a/Sources/ExtrasBase64/Chromium.swift
+++ b/Sources/ExtrasBase64/Chromium.swift
@@ -274,6 +274,10 @@ extension Base64 {
 
     @inlinable
     public static func decode<Buffer: Collection>(bytes: Buffer, options: DecodingOptions = []) throws -> [UInt8] where Buffer.Element == UInt8 {
+        guard bytes.count > 0 else {
+            return []
+        }
+
         let decoded = try bytes.withContiguousStorageIfAvailable { (input) -> [UInt8] in
             let outputLength = ((input.count + 3) / 4) * 3
 

--- a/Tests/ExtrasBase64Tests/ChromiumTests.swift
+++ b/Tests/ExtrasBase64Tests/ChromiumTests.swift
@@ -42,6 +42,12 @@ class ChromiumTests: XCTestCase {
         XCTAssertEqual(decoded?.count, 0)
     }
 
+    func testDecodeEmptyBytes() throws {
+        var decoded: [UInt8]?
+        XCTAssertNoThrow(decoded = try Base64.decode(bytes: []))
+        XCTAssertEqual(decoded?.count, 0)
+    }
+
     func testBase64DecodingArrayOfNulls() throws {
         let expected = Array(repeating: UInt8(0), count: 10)
         var decoded: [UInt8]?


### PR DESCRIPTION
This pull request fixes a crash when the byte collection to decode is empty.
I also added a test for this case.