### PR TITLE
Rename encodeBytes to encodeToBytes, encodeString to encodeToString

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/test_base32_encoding.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_base32_encoding.swift
@@ -6,7 +6,7 @@ func run(identifier: String) {
 
     measure(identifier: identifier) {
         for _ in 0 ..< 1000 {
-            base32 = Base32.encodeString(bytes: bytes)
+            base32 = Base32.encodeToString(bytes: bytes)
         }
 
         return base32?.count ?? 0

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_base64_encoding.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_base64_encoding.swift
@@ -6,7 +6,7 @@ func run(identifier: String) {
 
     measure(identifier: identifier) {
         for _ in 0 ..< 1000 {
-            base64 = Base64.encodeString(bytes: bytes)
+            base64 = Base64.encodeToString(bytes: bytes)
         }
 
         return base64?.count ?? 0

--- a/Sources/ExtrasBase64/Base32.swift
+++ b/Sources/ExtrasBase64/Base32.swift
@@ -3,7 +3,7 @@
 public extension String {
     /// Create a base32 encoded string from a buffer
     init<Buffer: Collection>(base32Encoding bytes: Buffer, options: Base32.EncodingOptions = []) where Buffer.Element == UInt8 {
-        self = Base32.encodeString(bytes: bytes, options: options)
+        self = Base32.encodeToString(bytes: bytes, options: options)
     }
 
     /// Decode base32 encoded strin
@@ -19,7 +19,7 @@ public enum Base32 {
         public let rawValue: UInt
         public init(rawValue: UInt) { self.rawValue = rawValue }
 
-        public static let includePadding = EncodingOptions(rawValue: UInt(1 << 0))
+        public static let omitPaddingCharacter = EncodingOptions(rawValue: UInt(1 << 0))
     }
 
     public enum DecodingError: Swift.Error, Equatable {
@@ -27,7 +27,7 @@ public enum Base32 {
     }
 
     /// Base32 Encode a buffer to an array of bytes
-    public static func encodeBytes<Buffer: Collection>(
+    public static func encodeToBytes<Buffer: Collection>(
         bytes: Buffer,
         options: EncodingOptions = []
     ) -> [UInt8] where Buffer.Element == UInt8 {
@@ -42,11 +42,11 @@ public enum Base32 {
             return result
         }
 
-        return self.encodeBytes(bytes: Array(bytes))
+        return self.encodeToBytes(bytes: Array(bytes))
     }
 
     /// Base32 Encode a buffer to a string
-    public static func encodeString<Buffer: Collection>(
+    public static func encodeToString<Buffer: Collection>(
         bytes: Buffer,
         options: EncodingOptions = []
     ) -> String where Buffer.Element == UInt8 {
@@ -62,9 +62,9 @@ public enum Base32 {
                 return result
             }
 
-            return self.encodeString(bytes: Array(bytes))
+            return self.encodeToString(bytes: Array(bytes))
         } else {
-            let bytes: [UInt8] = self.encodeBytes(bytes: bytes)
+            let bytes: [UInt8] = self.encodeToBytes(bytes: bytes)
             return String(decoding: bytes, as: Unicode.UTF8.self)
         }
     }
@@ -249,7 +249,7 @@ extension Base32 {
             preconditionFailure("Shouldn't get here")
         }
         outputIndex += (remainingBytes * 8 + 4) / 5
-        if options.contains(.includePadding) {
+        if !options.contains(.omitPaddingCharacter) {
             let fullOutputSize = ((outputIndex + 7) / 8) * 8
             while outputIndex < fullOutputSize {
                 output[outputIndex] = UInt8(ascii: "=")

--- a/Sources/ExtrasBase64/Base64.swift
+++ b/Sources/ExtrasBase64/Base64.swift
@@ -62,7 +62,7 @@ public extension String {
     init<Buffer: Collection>(base64Encoding bytes: Buffer, options: Base64.EncodingOptions = [])
         where Buffer.Element == UInt8
     {
-        self = Base64.encodeString(bytes: bytes, options: options)
+        self = Base64.encodeToString(bytes: bytes, options: options)
     }
 
     func base64decoded(options: Base64.DecodingOptions = []) throws -> [UInt8] {
@@ -207,7 +207,7 @@ extension Base64 {
     ]
 
     @inlinable
-    public static func encodeBytes<Buffer: Collection>(bytes: Buffer, options: EncodingOptions = [])
+    public static func encodeToBytes<Buffer: Collection>(bytes: Buffer, options: EncodingOptions = [])
         -> [UInt8] where Buffer.Element == UInt8
     {
         let newCapacity = ((bytes.count + 2) / 3) * 4
@@ -220,11 +220,11 @@ extension Base64 {
             return result
         }
 
-        return self.encodeBytes(bytes: Array(bytes), options: options)
+        return self.encodeToBytes(bytes: Array(bytes), options: options)
     }
 
     @inlinable
-    public static func encodeString<Buffer: Collection>(bytes: Buffer, options: EncodingOptions = [])
+    public static func encodeToString<Buffer: Collection>(bytes: Buffer, options: EncodingOptions = [])
         -> String where Buffer.Element == UInt8
     {
         let newCapacity = ((bytes.count + 2) / 3) * 4
@@ -241,9 +241,9 @@ extension Base64 {
                 return result
             }
 
-            return self.encodeString(bytes: Array(bytes), options: options)
+            return self.encodeToString(bytes: Array(bytes), options: options)
         } else {
-            let bytes: [UInt8] = self.encodeBytes(bytes: bytes, options: options)
+            let bytes: [UInt8] = self.encodeToBytes(bytes: bytes, options: options)
             return String(decoding: bytes, as: Unicode.UTF8.self)
         }
         #else

--- a/Sources/PerformanceTest/main.swift
+++ b/Sources/PerformanceTest/main.swift
@@ -35,19 +35,19 @@ let foundationEncodingData = timing(name: "Foundation: Data to Data    ") {
 
 let chromeEncodingBytes = timing(name: "Chromium: [UInt8] to [UInt8]") {
     for _ in 1 ... runs {
-        let _: [UInt8] = Base64.encodeBytes(bytes: bytes)
+        let _: [UInt8] = Base64.encodeToBytes(bytes: bytes)
     }
 }
 
 let chromeEncodingString = timing(name: "Chromium: [UInt8] to String ") {
     for _ in 1 ... runs {
-        let _: String = Base64.encodeString(bytes: bytes)
+        let _: String = Base64.encodeToString(bytes: bytes)
     }
 }
 
 let chromeEncodingData = timing(name: "Chromium: Data    to [UInt8]") {
     for _ in 1 ... runs {
-        let _: String = Base64.encodeString(bytes: data)
+        let _: String = Base64.encodeToString(bytes: data)
     }
 }
 

--- a/Tests/ExtrasBase64Tests/Base32Tests.swift
+++ b/Tests/ExtrasBase64Tests/Base32Tests.swift
@@ -6,20 +6,20 @@ class Base32Tests: XCTestCase {
 
     func testEncodeEmptyData() {
         let data = [UInt8]()
-        let encodedData: [UInt8] = Base32.encodeBytes(bytes: data)
+        let encodedData: [UInt8] = Base32.encodeToBytes(bytes: data)
         XCTAssertEqual(encodedData.count, 0)
     }
 
     func testBase32EncodingArrayOfNulls() {
         let data = Array(repeating: UInt8(0), count: 10)
-        let encodedData: [UInt8] = Base32.encodeBytes(bytes: data)
+        let encodedData: [UInt8] = Base32.encodeToBytes(bytes: data)
         XCTAssertEqual(encodedData, [UInt8]("AAAAAAAAAAAAAAAA".utf8))
     }
 
     func testBase32EncodingAllTheBytesSequentially() {
         let data = Array(UInt8(0) ... UInt8(255))
-        let encodedData = Base32.encodeBytes(bytes: data)
-        XCTAssertEqual(encodedData, [UInt8]("AAAQEAYEAUDAOCAJBIFQYDIOB4IBCEQTCQKRMFYYDENBWHA5DYPSAIJCEMSCKJRHFAUSUKZMFUXC6MBRGIZTINJWG44DSOR3HQ6T4P2AIFBEGRCFIZDUQSKKJNGE2TSPKBIVEU2UKVLFOWCZLJNVYXK6L5QGCYTDMRSWMZ3INFVGW3DNNZXXA4LSON2HK5TXPB4XU634PV7H7AEBQKBYJBMGQ6EITCULRSGY5D4QSGJJHFEVS2LZRGM2TOOJ3HU7UCQ2FI5EUWTKPKFJVKV2ZLNOV6YLDMVTWS23NN5YXG5LXPF5X274BQOCYPCMLRWHZDE4VS6MZXHM7UGR2LJ5JVOW27MNTWW33TO55X7A4HROHZHF43T6R2PK5PWO33XP6DY7F47U6X3PP6HZ7L57Z7P674".utf8))
+        let encodedData = Base32.encodeToBytes(bytes: data)
+        XCTAssertEqual(encodedData, [UInt8]("AAAQEAYEAUDAOCAJBIFQYDIOB4IBCEQTCQKRMFYYDENBWHA5DYPSAIJCEMSCKJRHFAUSUKZMFUXC6MBRGIZTINJWG44DSOR3HQ6T4P2AIFBEGRCFIZDUQSKKJNGE2TSPKBIVEU2UKVLFOWCZLJNVYXK6L5QGCYTDMRSWMZ3INFVGW3DNNZXXA4LSON2HK5TXPB4XU634PV7H7AEBQKBYJBMGQ6EITCULRSGY5D4QSGJJHFEVS2LZRGM2TOOJ3HU7UCQ2FI5EUWTKPKFJVKV2ZLNOV6YLDMVTWS23NN5YXG5LXPF5X274BQOCYPCMLRWHZDE4VS6MZXHM7UGR2LJ5JVOW27MNTWW33TO55X7A4HROHZHF43T6R2PK5PWO33XP6DY7F47U6X3PP6HZ7L57Z7P674======".utf8))
     }
 
     // MARK: Decoding
@@ -61,10 +61,10 @@ class Base32Tests: XCTestCase {
     }
 
     func testBase32DecodingOneTwoThreeFour() {
-        let base32 = "AEBAGBA"
+        let base32 = "AEBAGBA="
         let bytes: [UInt8] = [1, 2, 3, 4]
 
-        XCTAssertEqual(Base32.encodeString(bytes: bytes), base32)
+        XCTAssertEqual(Base32.encodeToString(bytes: bytes), base32)
         XCTAssertEqual(try Base32.decode(string: base32), bytes)
     }
 
@@ -72,7 +72,7 @@ class Base32Tests: XCTestCase {
         let base32 = "AEBAGBAF"
         let bytes: [UInt8] = [1, 2, 3, 4, 5]
 
-        XCTAssertEqual(Base32.encodeString(bytes: bytes), base32)
+        XCTAssertEqual(Base32.encodeToString(bytes: bytes), base32)
         XCTAssertEqual(try Base32.decode(string: base32), bytes)
     }
 
@@ -80,7 +80,7 @@ class Base32Tests: XCTestCase {
         let base32 = "AEBAGBAFAY"
         let bytes: [UInt8] = [1, 2, 3, 4, 5, 6]
 
-        XCTAssertEqual(Base32.encodeString(bytes: bytes), base32)
+        XCTAssertEqual(Base32.encodeToString(bytes: bytes, options: .omitPaddingCharacter), base32)
         XCTAssertEqual(try Base32.decode(string: base32), bytes)
     }
 
@@ -88,27 +88,27 @@ class Base32Tests: XCTestCase {
         let base32 = "AEBAGBAFAY======"
         let bytes: [UInt8] = [1, 2, 3, 4, 5, 6]
 
-        XCTAssertEqual(Base32.encodeString(bytes: bytes, options: .includePadding), base32)
+        XCTAssertEqual(Base32.encodeToString(bytes: bytes), base32)
         XCTAssertEqual(try base32.base32decoded(), bytes)
     }
 
     func testBase32EncodeFoobar() {
-        XCTAssertEqual(String(base32Encoding: "".utf8), "")
-        XCTAssertEqual(String(base32Encoding: "f".utf8), "MY")
-        XCTAssertEqual(String(base32Encoding: "fo".utf8), "MZXQ")
-        XCTAssertEqual(String(base32Encoding: "foo".utf8), "MZXW6")
-        XCTAssertEqual(String(base32Encoding: "foob".utf8), "MZXW6YQ")
-        XCTAssertEqual(String(base32Encoding: "fooba".utf8), "MZXW6YTB")
-        XCTAssertEqual(String(base32Encoding: "foobar".utf8), "MZXW6YTBOI")
+        XCTAssertEqual(String(base32Encoding: "".utf8, options: .omitPaddingCharacter), "")
+        XCTAssertEqual(String(base32Encoding: "f".utf8, options: .omitPaddingCharacter), "MY")
+        XCTAssertEqual(String(base32Encoding: "fo".utf8, options: .omitPaddingCharacter), "MZXQ")
+        XCTAssertEqual(String(base32Encoding: "foo".utf8, options: .omitPaddingCharacter), "MZXW6")
+        XCTAssertEqual(String(base32Encoding: "foob".utf8, options: .omitPaddingCharacter), "MZXW6YQ")
+        XCTAssertEqual(String(base32Encoding: "fooba".utf8, options: .omitPaddingCharacter), "MZXW6YTB")
+        XCTAssertEqual(String(base32Encoding: "foobar".utf8, options: .omitPaddingCharacter), "MZXW6YTBOI")
     }
 
     func testBase32EncodeFoobarWithPadding() {
-        XCTAssertEqual(String(base32Encoding: "".utf8, options: .includePadding), "")
-        XCTAssertEqual(String(base32Encoding: "f".utf8, options: .includePadding), "MY======")
-        XCTAssertEqual(String(base32Encoding: "fo".utf8, options: .includePadding), "MZXQ====")
-        XCTAssertEqual(String(base32Encoding: "foo".utf8, options: .includePadding), "MZXW6===")
-        XCTAssertEqual(String(base32Encoding: "foob".utf8, options: .includePadding), "MZXW6YQ=")
-        XCTAssertEqual(String(base32Encoding: "fooba".utf8, options: .includePadding), "MZXW6YTB")
-        XCTAssertEqual(String(base32Encoding: "foobar".utf8, options: .includePadding), "MZXW6YTBOI======")
+        XCTAssertEqual(String(base32Encoding: "".utf8), "")
+        XCTAssertEqual(String(base32Encoding: "f".utf8), "MY======")
+        XCTAssertEqual(String(base32Encoding: "fo".utf8), "MZXQ====")
+        XCTAssertEqual(String(base32Encoding: "foo".utf8), "MZXW6===")
+        XCTAssertEqual(String(base32Encoding: "foob".utf8), "MZXW6YQ=")
+        XCTAssertEqual(String(base32Encoding: "fooba".utf8), "MZXW6YTB")
+        XCTAssertEqual(String(base32Encoding: "foobar".utf8), "MZXW6YTBOI======")
     }
 }

--- a/Tests/ExtrasBase64Tests/ChromiumTests.swift
+++ b/Tests/ExtrasBase64Tests/ChromiumTests.swift
@@ -6,31 +6,31 @@ class ChromiumTests: XCTestCase {
 
     func testEncodeEmptyData() {
         let data = [UInt8]()
-        let encodedData: [UInt8] = Base64.encodeBytes(bytes: data)
+        let encodedData: [UInt8] = Base64.encodeToBytes(bytes: data)
         XCTAssertEqual(encodedData.count, 0)
     }
 
     func testBase64EncodingArrayOfNulls() {
         let data = Array(repeating: UInt8(0), count: 10)
-        let encodedData: [UInt8] = Base64.encodeBytes(bytes: data)
+        let encodedData: [UInt8] = Base64.encodeToBytes(bytes: data)
         XCTAssertEqual(encodedData, [UInt8]("AAAAAAAAAAAAAA==".utf8))
     }
 
     func testBase64EncodingAllTheBytesSequentially() {
         let data = Array(UInt8(0) ... UInt8(255))
-        let encodedData: [UInt8] = Base64.encodeBytes(bytes: data)
+        let encodedData: [UInt8] = Base64.encodeToBytes(bytes: data)
         XCTAssertEqual(encodedData, [UInt8]("AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+/w==".utf8))
     }
 
     func testBase64UrlEncodingAllTheBytesSequentially() {
         let data = Array(UInt8(0) ... UInt8(255))
-        let encodedData: [UInt8] = Base64.encodeBytes(bytes: data, options: .base64UrlAlphabet)
+        let encodedData: [UInt8] = Base64.encodeToBytes(bytes: data, options: .base64UrlAlphabet)
         XCTAssertEqual(encodedData, [UInt8]("AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0-P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn-AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq-wsbKztLW2t7i5uru8vb6_wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t_g4eLj5OXm5-jp6uvs7e7v8PHy8_T19vf4-fr7_P3-_w==".utf8))
     }
 
     func testBase64UrlEncodingAllTheBytesSequentiallyOmitPadding() {
         let data = Array(UInt8(0) ... UInt8(255))
-        let encodedData: [UInt8] = Base64.encodeBytes(bytes: data, options: [.base64UrlAlphabet, .omitPaddingCharacter])
+        let encodedData: [UInt8] = Base64.encodeToBytes(bytes: data, options: [.base64UrlAlphabet, .omitPaddingCharacter])
         XCTAssertEqual(encodedData, [UInt8]("AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0-P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn-AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq-wsbKztLW2t7i5uru8vb6_wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t_g4eLj5OXm5-jp6uvs7e7v8PHy8_T19vf4-fr7_P3-_w".utf8))
     }
 
@@ -96,7 +96,7 @@ class ChromiumTests: XCTestCase {
         let base64 = "AQIDBA=="
         let bytes: [UInt8] = [1, 2, 3, 4]
 
-        XCTAssertEqual(Base64.encodeString(bytes: bytes), base64)
+        XCTAssertEqual(Base64.encodeToString(bytes: bytes), base64)
         XCTAssertEqual(try Base64.decode(string: base64), bytes)
     }
 
@@ -104,7 +104,7 @@ class ChromiumTests: XCTestCase {
         let base64 = "AQIDBAU="
         let bytes: [UInt8] = [1, 2, 3, 4, 5]
 
-        XCTAssertEqual(Base64.encodeString(bytes: bytes), base64)
+        XCTAssertEqual(Base64.encodeToString(bytes: bytes), base64)
         XCTAssertEqual(try Base64.decode(string: base64), bytes)
     }
 
@@ -112,7 +112,7 @@ class ChromiumTests: XCTestCase {
         let base64 = "AQIDBAUG"
         let bytes: [UInt8] = [1, 2, 3, 4, 5, 6]
 
-        XCTAssertEqual(Base64.encodeString(bytes: bytes), base64)
+        XCTAssertEqual(Base64.encodeToString(bytes: bytes), base64)
         XCTAssertEqual(try Base64.decode(string: base64), bytes)
     }
 

--- a/Tests/ExtrasBase64Tests/IntegrationTests.swift
+++ b/Tests/ExtrasBase64Tests/IntegrationTests.swift
@@ -5,7 +5,7 @@ class IntegrationTests: XCTestCase {
     func testEncodeAndDecodingĨ() throws {
         var input = "Ĩ"
         let encoded = input.withUTF8 { ptr -> String in
-            Base64.encodeString(bytes: ptr)
+            Base64.encodeToString(bytes: ptr)
         }
 
         let decoded = try Base64.decode(string: encoded)


### PR DESCRIPTION
Makes it clearer what the Bytes and String mean in the function name